### PR TITLE
fix: wrapping route components with lazy, suspense

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3555,6 +3555,15 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6464,6 +6473,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -9402,6 +9417,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -14846,7 +14867,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -15295,7 +15320,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import * as S from './style'
 import SearchOutlined from '@ant-design/icons/SearchOutlined'
 
-const Header = () => {
+const Header: React.FC = () => {
   return (
     <S.StyledContainer>
       <S.Logo>오이마켓</S.Logo>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,30 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
 import Header from '../components/Header'
-import Main from './Main'
-import Search from './Search'
-import Detail from './Detail'
+import styled from 'styled-components'
+
+const Main = React.lazy(() => import('pages/Main'))
+const Search = React.lazy(() => import('pages/Search'))
+const Detail = React.lazy(() => import('pages/Detail'))
+
+const SwitchWrapper = styled.div`
+  position: relative;
+  top: 60px;
+`
 
 const RouteWrapper: React.FC = () => {
   return (
     <Router>
       <Header />
-      <Switch>
-        <Route path="/" exact component={Main} />
-        <Route path="/search/:word" exact component={Search} />
-        <Route path="/articles/:id" exact component={Detail} />
-      </Switch>
+      <SwitchWrapper>
+        <Switch>
+          <Suspense fallback={<div>Loading...</div>}>
+            <Route path="/" exact component={Main} />
+            <Route path="/search/:word" exact component={Search} />
+            <Route path="/articles/:id" exact component={Detail} />
+          </Suspense>
+        </Switch>
+      </SwitchWrapper>
     </Router>
   )
 }


### PR DESCRIPTION
라우터 컴포넌트를 `lazy`와 `suspense`로 랩핑했습니다. 나중에 빌드할 때 라우트 별로 코드가 분할되서 좋은 것 같아요.

fallback은 분할된 파일을 불러올 때 까지 보여줄 화면인데, 진행하면서 수정할 예정이고

작성하시는 컴포넌트들의 타입을 정해주셔야 해요. 예를 들어 Header 라는 컴포넌트를 작성하고 export defaul로 내보낸다고 가정하면

```ts
const Header = () => { ... }
```

위를

```ts
const Header: React.FC = () => { ... }
// 또는 정의된 타입의 props를 가질 때
type HeaderProps = {
  props1: string
  props2: string
}

const Header: React.FC<HeaderProps> = ({ props1, props2 }) => { ... }
```

위와 같이 사용하면 될 것 같습니다.