### PR TITLE
반응형 컨테이너 컴포넌트 추가 및 헤더 스타일 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
-    'prettier/prettier': 0
+    'prettier/prettier': 0,
+    'react/prop-types': 'off'
   }
 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,18 +1,26 @@
 import React from 'react'
 import * as S from './style'
 import SearchOutlined from '@ant-design/icons/SearchOutlined'
+import Container from 'components/common/Container'
 
 const Header: React.FC = () => {
   return (
     <S.StyledContainer>
-      <S.Logo>오이마켓</S.Logo>
-      <S.InputBox>
-        <input type="text" placeholder="동네 이름, 물품명 등을 검색해보세요!" />
-        <SearchOutlined />
-      </S.InputBox>
-      <S.Menu>
-        <li>SIGN IN</li>
-      </S.Menu>
+      <Container rowProps={{ justify: 'center', style: { width: '100%' } }}>
+        <S.InnerWrapper>
+          <S.Logo>오이마켓</S.Logo>
+          <S.InputBox>
+            <input
+              type="text"
+              placeholder="동네 이름, 물품명 등을 검색해보세요!"
+            />
+            <SearchOutlined />
+          </S.InputBox>
+          <S.Menu>
+            <li>SIGN IN</li>
+          </S.Menu>
+        </S.InnerWrapper>
+      </Container>
     </S.StyledContainer>
   )
 }

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -8,8 +8,6 @@ export const StyledContainer = styled.div`
   left: 0;
   background-color: ${({ theme }) => theme.colors.white};
   display: flex;
-  justify-content: space-around;
-  align-items: center;
 `
 
 export const Logo = styled.div`
@@ -47,4 +45,13 @@ export const Menu = styled.ul`
   li {
     list-style: none;
   }
+`
+
+export const InnerWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 10px;
 `

--- a/src/components/common/Container/index.tsx
+++ b/src/components/common/Container/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Row, Col, RowProps, ColProps } from 'antd'
+
+interface ContainerProps {
+  rowProps?: RowProps
+  colProps?: ColProps
+}
+
+interface ColumnsWidth {
+  xs: number
+  md: number
+  lg: number
+  xl: number
+  xxl: number
+}
+
+export const Column: Partial<ColumnsWidth> = {
+  xs: 24,
+  md: 18,
+  lg: 12,
+  xl: 10
+}
+
+const Container: React.FC<ContainerProps> = ({
+  rowProps = {},
+  colProps = {},
+  children
+}) => {
+  return (
+    <Row justify="center" gutter={10} align="middle" {...rowProps}>
+      <Col {...colProps} {...Column}>
+        {children}
+      </Col>
+    </Row>
+  )
+}
+
+export default Container

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Create: React.FC = () => {
+  return <div>상품 등록</div>
+}
+
+export default Create

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,30 +1,32 @@
 import React, { Suspense } from 'react'
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
-import Header from '../components/Header'
-import styled from 'styled-components'
+import Header from 'components/Header'
+import Container from 'components/common/Container'
 
 const Main = React.lazy(() => import('pages/Main'))
 const Search = React.lazy(() => import('pages/Search'))
 const Detail = React.lazy(() => import('pages/Detail'))
+const Create = React.lazy(() => import('pages/Create'))
 
-const SwitchWrapper = styled.div`
-  position: relative;
-  top: 60px;
-`
+const ContainerStyle: React.CSSProperties = {
+  top: '80px',
+  position: 'relative'
+}
 
 const RouteWrapper: React.FC = () => {
   return (
     <Router>
       <Header />
-      <SwitchWrapper>
+      <Container rowProps={{ style: ContainerStyle }}>
         <Switch>
           <Suspense fallback={<div>Loading...</div>}>
             <Route path="/" exact component={Main} />
             <Route path="/search/:word" exact component={Search} />
+            <Route path="/article/create" exact component={Create} />
             <Route path="/articles/:id" exact component={Detail} />
           </Suspense>
         </Switch>
-      </SwitchWrapper>
+      </Container>
     </Router>
   )
 }


### PR DESCRIPTION
반응형 컨테이너 컴포넌트를 추가했어요. 페이지 컴포넌트를 감싸는 상위에 해당 컴포넌트 위치시키고 헤더에도 적용시켰습니다.

해당 컨테이너가 필요한 부분에 사용하면 될 것 같습니다!

스타일은 `rowProps` 속성을 주어 row 스타일을 변경시키거나 `colProps`를 주어 col 스타일을 변경시키면 됩니다.