### PR TITLE
type 설정 방식 변경

### DIFF
--- a/src/api/address/index.ts
+++ b/src/api/address/index.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosResponse } from 'axios'
-import type { ChildAddress, ParentAddress } from 'types/address'
 
 // 광역시,도를 가져옵니다.
 export const getParentAddress: () => Promise<ParentAddress[]> = async () => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -30,7 +30,7 @@ const Header: React.FC = () => {
             <SearchOutlined />
           </InputBox>
           <Menu>
-            {isSignIn ? (
+            {!isSignIn ? (
               <>
                 <li>
                   <Link to="/my-info">내 정보</Link>

--- a/src/components/auth/hooks/address.ts
+++ b/src/components/auth/hooks/address.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { getChildAddress, getParentAddress } from 'api/address'
-import { ChildAddress, ParentAddress } from 'types/address'
 
 // 광역시,도
 // 첫 렌더링 때 가져옵니다.

--- a/src/components/common/ArticleBox/index.tsx
+++ b/src/components/common/ArticleBox/index.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { StyledContainer, ImgBox, ArticleInfo, SubInfo } from './style'
 import { HeartFilled, MessageOutlined } from '@ant-design/icons'
 
-const ArticleBox: React.FC<Article.ArticleInfo> = ({
+const ArticleBox: React.FC<ArticleInfo> = ({
   id,
   img,
   name,

--- a/src/components/detail/DetailInfo/index.tsx
+++ b/src/components/detail/DetailInfo/index.tsx
@@ -11,7 +11,7 @@ import { Button } from 'antd'
 import { HeartOutlined, HeartFilled, ShareAltOutlined } from '@ant-design/icons'
 
 interface DetailInfoProps {
-  articleInfo: Article.ArticleDetail
+  articleInfo: ArticleDetail
 }
 
 const DetailInfo: React.FC<DetailInfoProps> = ({ articleInfo }) => {

--- a/src/components/myInfo/Like/index.tsx
+++ b/src/components/myInfo/Like/index.tsx
@@ -3,7 +3,7 @@ import { StyledContainer, Title, EmptyBox } from './style'
 import ArticleBox from 'components/common/ArticleBox'
 
 interface LikeProps {
-  likeList: Article.ArticleInfo[]
+  likeList: ArticleInfo[]
 }
 
 const Like: React.FC<LikeProps> = ({ likeList }) => {

--- a/src/components/myInfo/Trade/index.tsx
+++ b/src/components/myInfo/Trade/index.tsx
@@ -3,8 +3,8 @@ import { StyledContainer, Title, EmptyBox } from './style'
 import ArticleBox from 'components/common/ArticleBox'
 
 interface TradeProps {
-  buyList: Article.ArticleInfo[]
-  sellList: Article.ArticleInfo[]
+  buyList: ArticleInfo[]
+  sellList: ArticleInfo[]
 }
 
 const Trade: React.FC<TradeProps> = ({ buyList, sellList }) => {

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -11,7 +11,7 @@ const imgList = [
   'https://dnvefa72aowie.cloudfront.net/origin/article/202103/E1F4AA664E524FD622535207EEB9A445165DB89079455111AD4E48433DDB20F5.jpg?q=82&s=300x300&t=crop'
 ]
 
-const detail: Article.ArticleDetail = {
+const detail: ArticleDetail = {
   id: 1,
   img: [
     'https://dnvefa72aowie.cloudfront.net/origin/article/202103/E1F4AA664E524FD622535207EEB9A445165DB89079455111AD4E48433DDB20F5.jpg?q=82&s=300x300&t=crop',

--- a/src/pages/MyInfo.tsx
+++ b/src/pages/MyInfo.tsx
@@ -8,7 +8,7 @@ import Like from 'components/myInfo/Like'
 import { Col, Row } from 'antd'
 
 // test data
-const article: Article.ArticleInfo = {
+const article: ArticleInfo = {
   img:
     'https://dnvefa72aowie.cloudfront.net/origin/article/202103/E1F4AA664E524FD622535207EEB9A445165DB89079455111AD4E48433DDB20F5.jpg?q=82&s=300x300&t=crop',
   name: '자전거팝니다',

--- a/src/types/address.d.ts
+++ b/src/types/address.d.ts
@@ -1,9 +1,13 @@
-export type ParentAddress = {
-  id: number
-  name: string
-}
+export {}
 
-export type ChildAddress = {
-  city: string
-  streetList: string[]
+declare global {
+  export type ParentAddress = {
+    id: number
+    name: string
+  }
+
+  export type ChildAddress = {
+    city: string
+    streetList: string[]
+  }
 }

--- a/src/types/article.d.ts
+++ b/src/types/article.d.ts
@@ -1,4 +1,6 @@
-declare namespace Article {
+export {}
+
+declare global {
   interface ArticleInfo {
     id?: number
     img: string
@@ -25,6 +27,3 @@ declare namespace Article {
     desc: string
   }
 }
-
-// null과 undefined를 가질 수 있는 타입 정의
-declare type Nullable<T> = T | null | undefined

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,6 @@
+export {}
+
+declare global {
+  // null과 undefined를 가질 수 있는 타입 정의
+  type Nullable<T> = T | null | undefined
+}

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,0 +1,20 @@
+export {}
+
+declare global {
+  export type SignUpInfo = {
+    name: string
+    password: string
+    city: string
+    street1: string
+    street2: string
+    zipcode: string
+    email: string
+    birthDate: string
+    contact: string
+  }
+
+  export type SignInInfo = {
+    id: string
+    password: string
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "typeRoots": ["./src/type.d.ts"]
+    "typeRoots": ["src/types/*"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
- types 폴더 내에서 모든 타입을 관리하는게 나을것같아서 구조를 바꿔봤습니다.
- 파일내에서 타입을 import 할 필요없이 global로 모든 타입을 사용할 수 있습니다.
- 그런데 경환님이 우려하신 부분인 타입명과 다른 변수들명이 겹칠것같다는 부분은 해결하지 못했는데, 코드를 보시고 이 방식으로 하는것이 불편하실것같다면 말씀해주세요!