### PR TITLE
feat: RequiredLogin 컴포넌트 추가

### DIFF
--- a/src/components/auth/RequiredLogin/index.tsx
+++ b/src/components/auth/RequiredLogin/index.tsx
@@ -3,7 +3,9 @@ import userContext from 'context/user'
 import React, { useContext, useEffect } from 'react'
 import { useHistory } from 'react-router'
 
-const RequiredLogin: React.FC = () => {
+const withRequiredLogin: (c: React.ComponentType) => React.ReactElement = (
+  Component
+) => {
   const { isLoggedIn } = useContext(userContext)
   const history = useHistory()
 
@@ -14,7 +16,7 @@ const RequiredLogin: React.FC = () => {
     }
   }, [])
 
-  return <></>
+  return <Component />
 }
 
-export default RequiredLogin
+export default withRequiredLogin

--- a/src/components/auth/RequiredLogin/index.tsx
+++ b/src/components/auth/RequiredLogin/index.tsx
@@ -1,0 +1,20 @@
+import { message } from 'antd'
+import userContext from 'context/user'
+import React, { useContext, useEffect } from 'react'
+import { useHistory } from 'react-router'
+
+const RequiredLogin: React.FC = () => {
+  const { isLoggedIn } = useContext(userContext)
+  const history = useHistory()
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      history.push('/')
+      message.error({ content: '해당 페이지는 로그인이 필요합니다.' })
+    }
+  }, [])
+
+  return <></>
+}
+
+export default RequiredLogin

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,3 +1,4 @@
+import RequiredLogin from 'components/auth/RequiredLogin'
 import ChatList from 'components/chat/contents/ChatList'
 import ChatMain from 'components/chat/contents/Main'
 import ChatUserInfo from 'components/chat/contents/UserInfo'
@@ -12,6 +13,7 @@ const Chat: React.FC = () => {
       {left ? <ChatList /> : null}
       <ChatMain />
       {right ? <ChatUserInfo /> : null}
+      <RequiredLogin />
     </>
   )
 }

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,4 +1,4 @@
-import RequiredLogin from 'components/auth/RequiredLogin'
+import withRequiredLogin from 'components/auth/RequiredLogin'
 import ChatList from 'components/chat/contents/ChatList'
 import ChatMain from 'components/chat/contents/Main'
 import ChatUserInfo from 'components/chat/contents/UserInfo'
@@ -13,9 +13,8 @@ const Chat: React.FC = () => {
       {left ? <ChatList /> : null}
       <ChatMain />
       {right ? <ChatUserInfo /> : null}
-      <RequiredLogin />
     </>
   )
 }
 
-export default Chat
+export default withRequiredLogin(Chat)


### PR DESCRIPTION
해당 컴포넌트를 포함시키면 로그인이 필요한 페이지로 간주하고 로그인이 되어있지 않은 상태면 메인 페이지로 이동시킵니다. 필요할 것 같아서 미리 만들어놨습니다. 예를 들어 채팅 페이지 같은 경우 로그인이 필요합니다. 페이지 컴포넌트에서 일일이 작성하면 번거로울 것 같고 다른 곳에서 쓰일 수도 있을 것 같아서 만들었습니다.

더 필요한 기능이 있을 것 같으면 말씀해주세요~